### PR TITLE
Fix link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # SvelteKit Auth with JWT
 
-Related blog post: https://okupter.com/blog/handling-auth-with-jwt-in-sveltekit.
+Related blog post: [Handling authentication and authorization with JWT in SvelteKit](https://www.okupter.com/blog/handling-auth-with-jwt-in-sveltekit).


### PR DESCRIPTION
Updated link to blog posts to include "www" as the okupter is a naked domain.